### PR TITLE
Allow saving null for decimal pint field

### DIFF
--- a/src/django_pint_field/forms.py
+++ b/src/django_pint_field/forms.py
@@ -304,7 +304,7 @@ class DecimalPintFormField(BasePintFormField):
 
         if hasattr(quantity, "magnitude") and isinstance(quantity.magnitude, Decimal):
             validate_decimal_precision(quantity)
-        else:
+        elif quantity is not None:
             try:
                 quantity = self.ureg.Quantity(quantity)
             except Exception as e:


### PR DESCRIPTION
Currently a DecimalPintField(null=True, blank=True) isn't optional in django admin.